### PR TITLE
Added the class and target properties into LINK entity

### DIFF
--- a/src/library/getEntityId.js
+++ b/src/library/getEntityId.js
@@ -18,6 +18,8 @@ const getEntityId = (node) => {
     } else {
       entityConfig.url = node.href;
       entityConfig.title = node.innerHTML;
+      entityConfig.className = node.className;
+      entityConfig.target = node.target;
       entityId = Entity.create(
         'LINK',
         'MUTABLE',


### PR DESCRIPTION
Hi @jpuri, this PR is necessary for the others in the react-draft-wysiwyg repository.

To added the target option for the user we need to be able to keep this information when he decides to edit the content, so we need to receive the target through the entity.

To have the possibility to change the look and feel of internal links is necessary a different class so I added the className into the library to receive it again.

I would be very happy with those options :)