### PR TITLE
Iframe relative paths

### DIFF
--- a/src/library/index.js
+++ b/src/library/index.js
@@ -64,7 +64,7 @@ function genFragment(
     node instanceof HTMLIFrameElement
   ) {
     const entityConfig = {};
-    entityConfig.src = node.src;
+    entityConfig.src = node.getAttribute ? node.getAttribute('src') || node.src : node.src;
     entityConfig.height = node.height;
     entityConfig.width = node.width;
     const entityId = Entity.__create(


### PR DESCRIPTION
If I use a relative path inside the attribute src, the converted result will be undefined.
`<iframe src="/relative/path" width="200" height="200"></iframe>`

If we do the same you did a month ago with images, it will be solved. That's why I'm creating this PR. Let me know if you need a better explanation