### PR TITLE
Strip extraneous quotes on font-family

### DIFF
--- a/src/library/processInlineTag.js
+++ b/src/library/processInlineTag.js
@@ -24,7 +24,7 @@ export default function processInlineTag(
       const color = htmlElement.style.color;
       const backgroundColor = htmlElement.style.backgroundColor;
       const fontSize = htmlElement.style.fontSize;
-      const fontFamily = htmlElement.style.fontFamily;
+      const fontFamily = htmlElement.style.fontFamily.replace(/^"|"$/g, '');
       if (color) {
         style.add(`color-${color.replace(/ /g, '')}`);
       }


### PR DESCRIPTION
Otherwise it breaks the inline style:
`"style":"fontfamily-\"Times New Roman\""` instead of `"style":"fontfamily-Times New Roman"` and therefore is not recognized by draftjs.