### PR TITLE
Fixes #46

### DIFF
--- a/src/library/processInlineTag.js
+++ b/src/library/processInlineTag.js
@@ -32,7 +32,7 @@ export default function processInlineTag(
         style.add(`bgcolor-${backgroundColor.replace(/ /g, '')}`);
       }
       if (fontSize) {
-        style.add(`fontsize-${fontSize.substr(0, fontSize.length - 2)}`);
+        style.add(`fontsize-${fontSize.replace(/px$/g, '')}`);
       }
       if (fontFamily) {
         style.add(`fontfamily-${fontFamily}`);


### PR DESCRIPTION
Related issue: https://github.com/jpuri/html-to-draftjs/issues/46

This change explicitly removes the string `px` from a font-size, rather than just the last two characters